### PR TITLE
📝 App readme: start app with 'npm run start'

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -10,7 +10,7 @@ install the dependencies:
 ```npm install```
 
 run the app:
-```npm run```
+```npm run start```
 
 ## Develop!
 


### PR DESCRIPTION
Just a tiny change, this way the command from the readme actually starts the electron app. Only showing a help on how to start it (which `npm run` does) is a bit confusing to me