### PR TITLE
🔧 Run js formatter during pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,14 @@ repos:
         language: system
         files: app/.*
         pass_filenames: false
+-   repo: local
+    hooks:
+      -   id: npm_format
+          name: npm format
+          entry: bash -c "(cd app/ && (stat node_modules/ || npm i) && npm run format)"
+          language: system
+          files: app/.*
+          pass_filenames: false
 # TODO
 # -   repo: https://github.com/pre-commit/mirrors-mypy
 #     rev: 'v0.910'  # Use the sha / tag you want to point at

--- a/app/src/components/TitleBar.tsx
+++ b/app/src/components/TitleBar.tsx
@@ -7,7 +7,7 @@ function getWindowControlsRect(): DOMRect {
   if (windowControlsOverlay.visible) {
     return windowControlsOverlay.getBoundingClientRect();
   } else {
-    return new DOMRect(55, 0, window.innerWidth - 2*55, 55);
+    return new DOMRect(55, 0, window.innerWidth - 2 * 55, 55);
   }
 }
 const CloseIcon = styled(MdClose)`

--- a/app/src/start.ts
+++ b/app/src/start.ts
@@ -22,7 +22,7 @@ const createWindow = (): void => {
     frame: false,
     titleBarStyle: 'hiddenInset',
     titleBarOverlay: true,
-    trafficLightPosition: {x: 21, y: 21},
+    trafficLightPosition: { x: 21, y: 21 },
     webPreferences: {
       nodeIntegration: true,
       contextIsolation: false,

--- a/app/src/state/editor.ts
+++ b/app/src/state/editor.ts
@@ -46,7 +46,7 @@ export const play = createAsyncThunk<void, void, { state: RootState }>(
     const editor = getState().editor;
     assertEditor(editor);
     if (editor.playing) {
-      return
+      return;
     }
     dispatch(setPlay(true));
     const { document, currentTime } = editor;


### PR DESCRIPTION
This will run `npm run format` during the pre-commit hook. If any files are changed, the hook will fail. However it will leave the changes the formatter produced in the file tree, so they can be easily commited.