### PR TITLE
🐛 Race condition in selection onClick handlers

### DIFF
--- a/app/src/state/editor.ts
+++ b/app/src/state/editor.ts
@@ -214,10 +214,7 @@ export const importSlice = createSlice({
 
     setTime: (state, args: PayloadAction<number>) => {
       assertSome(state);
-      // we should only set the cursor if we are not already in a selection action
-      if (state.mouseSelection && state.selection !== null) return;
       state.currentTime = args.payload;
-      state.selection = null;
     },
     goLeft: (state) => {
       assertSome(state);
@@ -292,6 +289,7 @@ export const importSlice = createSlice({
       assertSome(state);
       state.mouseSelection = true;
       state.selectionStartItem = arg.payload;
+      state.selection = null;
     },
     mouseSelectionOver: (state, arg: PayloadAction<TimedParagraphItem>) => {
       assertSome(state);


### PR DESCRIPTION
From what I can tell the issue is that `mouseSelectionEnd` and `setTime` are both dispatched from the `click`-eventhandler. On my machine `setTime` is then processed after `mouseSelectionEnd`. So first `mouseSelectionEnd` sets the `state.mouseSelection` to `false`, which `setTime` checks and because of that it removes the selection.

I changed that by moving the selection reset to the `mouseSelectionStart` handler