### PR TITLE
🐛 Overwrite absoluteStart of items in computeTimed

### DIFF
--- a/app/src/core/document.ts
+++ b/app/src/core/document.ts
@@ -118,8 +118,8 @@ export function computeTimed(content: Paragraph[]): ParagraphGeneric<TimedParagr
       ...paragraph,
       content: paragraph.content.map((item) => {
         const mapped = {
-          absoluteStart: accumulatedTime,
           ...item,
+          absoluteStart: accumulatedTime,
         };
         accumulatedTime += item.length;
         return mapped;


### PR DESCRIPTION
The first element of a paragraph seems to sometimes have an "absoluteStart" set already, which seems to always be 0. This lead to some strange selection bugs, where some elements would be shown as selected without being in the selection and others not being shown as selected without being in the selection.