### PR TITLE
✨ Allow editing of text

### DIFF
--- a/app/src/pages/Editor/Paragraph.tsx
+++ b/app/src/pages/Editor/Paragraph.tsx
@@ -1,7 +1,7 @@
 import styled, { css } from 'styled-components';
 import quarterRest from '../../resources/quarter_rest.svg';
 import * as React from 'react';
-import { HTMLAttributes, MouseEventHandler } from 'react';
+import { DetailedHTMLProps, HTMLAttributes, MouseEventHandler, useRef, useState } from 'react';
 import { ParagraphGeneric, TimedParagraphItem } from '../../core/document';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../state';
@@ -14,7 +14,9 @@ import {
   pause,
   selectItem,
   selectParagraph,
+  setWord,
 } from '../../state/editor';
+import { assertSome } from '../../util';
 
 const ParagraphContainer = styled.div`
   user-select: none;
@@ -57,7 +59,77 @@ function ShortSilence(props: { selected: boolean } & HTMLAttributes<HTMLSpanElem
   );
 }
 
-const Word = styled.span<{ selected: boolean }>`
+export function Word({
+  word,
+  selected,
+  changehandler,
+  ...props
+}: DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> & {
+  word: string;
+  selected: boolean;
+  changehandler: (x: string) => void;
+}): JSX.Element {
+  const [editing, setEditing] = useState(false);
+  const ref = useRef<HTMLSpanElement>(null);
+
+  const startEditing = () => {
+    console.log('ref current', ref.current);
+    setEditing(true);
+    const range = document.createRange();
+    assertSome(ref.current);
+    range.selectNodeContents(ref.current);
+    const sel = window.getSelection();
+    assertSome(sel);
+    sel.removeAllRanges();
+    sel.addRange(range);
+    setTimeout(function () {
+      ref.current?.focus();
+    }, 0);
+  };
+
+  const stopEditing = () => {
+    setEditing(false);
+    const text = ref.current?.innerText;
+    assertSome(text);
+    if (text != word) {
+      changehandler(text);
+    }
+  };
+  const handleContextMenu = (event: React.MouseEvent) => {
+    event.preventDefault();
+    if (editing) {
+      stopEditing();
+    } else {
+      startEditing();
+    }
+  };
+  const editableProps = editing
+    ? {
+        onKeyDown: (e: React.KeyboardEvent) => {
+          e.stopPropagation();
+          if (e.key == 'Enter') {
+            stopEditing();
+          }
+        },
+        contentEditable: editing,
+        suppressContentEditableWarning: true,
+        onBlur: () => {
+          stopEditing();
+        },
+      }
+    : {};
+
+  return (
+    <SelectableSpan selected={selected}>
+      {' '}
+      <span {...props} {...editableProps} ref={ref} onContextMenu={handleContextMenu}>
+        {word}
+      </span>
+    </SelectableSpan>
+  );
+}
+
+const SelectableSpan = styled.span<{ selected: boolean }>`
   ${(props) =>
     props.selected &&
     css`
@@ -65,7 +137,6 @@ const Word = styled.span<{ selected: boolean }>`
       color: black;
     `}
 `;
-
 export function Paragraph({ speaker, content }: ParagraphGeneric<TimedParagraphItem>): JSX.Element {
   const playing = useSelector((state: RootState) => state.editor.present?.playing) || false;
   const selection = useSelector((state: RootState) => state.editor.present?.selection);
@@ -94,6 +165,10 @@ export function Paragraph({ speaker, content }: ParagraphGeneric<TimedParagraphI
             }
           };
           const onMouseDown: MouseEventHandler = (e) => {
+            if (e.button !== 0) {
+              // we only want to handle left clicks
+              return;
+            }
             dispatch(mouseSelectionStart(item));
             const listener = (e: MouseEvent) => {
               dispatch(mouseSelectionEnd());
@@ -118,10 +193,13 @@ export function Paragraph({ speaker, content }: ParagraphGeneric<TimedParagraphI
             selected: isSelected(item),
             className: 'item',
             key: i,
+            changehandler: (text: string) => {
+              dispatch(setWord({ text, absoluteStart: item.absoluteStart }));
+            },
           };
           switch (item.type) {
             case 'word':
-              return <Word {...commonProps}>{' ' + item.word}</Word>;
+              return <Word {...commonProps} word={item.word} />;
             case 'silence':
               if (item.length > 0.4) {
                 return <LongSilence {...commonProps} selected={isSelected(item)} />;

--- a/app/src/state/editor.ts
+++ b/app/src/state/editor.ts
@@ -502,6 +502,18 @@ export const importSlice = createSlice({
       state.currentTime = selection.start;
       state.selection = null;
     },
+
+    setWord: (state, arg: PayloadAction<{ absoluteStart: number; text: string }>) => {
+      console.log(state, arg.payload);
+      assertSome(state);
+      state.document.content = DocumentGenerator.fromParagraphs(state.document.content)
+        .itemMap((item) =>
+          item.absoluteStart == arg.payload.absoluteStart && item.type == 'word'
+            ? { ...item, word: arg.payload.text }
+            : item
+        )
+        .toParagraphs();
+    },
   },
   extraReducers: (builder) => {
     builder.addCase(openDocumentFromDisk.fulfilled, (state, action) => {
@@ -579,6 +591,8 @@ export const {
   insertParagraphBreak,
   deleteParagraphBreak,
   deleteSelection,
+
+  setWord,
 } = importSlice.actions;
 export default undoable(importSlice.reducer, {
   filter: includeAction([


### PR DESCRIPTION
Right-clicking on a word places it in edit-mode, rightclicking again, clicking somewhere else, pressing enter, or otherwise losing focus moves it out of edit mode and saves the changes

# Points for Discussion

I'm not sure what the proper UX for editing a word should be. I think right-clicking on a word in intuitive enough, but I'm not sure whether displaying a context menu with an "Edit word" option would be a better idea. 