### PR TITLE
🐛 Fix selection menu having wrong position on resize, scroll

### DIFF
--- a/app/src/pages/Editor/Document.tsx
+++ b/app/src/pages/Editor/Document.tsx
@@ -1,27 +1,20 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../state';
-import {
-  computeTimed,
-  DocumentGenerator,
-  Paragraph as ParagraphType,
-  ParagraphGeneric,
-  TimedParagraphItem,
-} from '../../core/document';
+import { computeTimed, Paragraph as ParagraphType } from '../../core/document';
 import * as React from 'react';
 import { KeyboardEventHandler, useEffect, useRef } from 'react';
 import {
+  copy,
   deleteSomething,
   goLeft,
   goRight,
   insertParagraphBreak,
+  paste,
+  saveDocument,
   selectLeft,
   selectRight,
-  unselect,
-  saveDocument,
   togglePlaying,
-  copy,
-  paste,
-  exportSelection,
+  unselect,
 } from '../../state/editor';
 import { ActionCreators } from 'redux-undo';
 import { Cursor } from './Cursor';
@@ -29,7 +22,7 @@ import { Paragraph } from './Paragraph';
 import { basename, extname } from 'path';
 import { Title } from '../../components/Util';
 import styled, { useTheme } from 'styled-components';
-import { SmallButton } from '../../components/Controls';
+import { SelectionMenu } from './SelectionMenu';
 
 const DocumentContainer = styled.div<{ displaySpeakerNames: boolean }>`
   position: relative;
@@ -55,72 +48,6 @@ const DocumentContainer = styled.div<{ displaySpeakerNames: boolean }>`
     outline: none;
   }
 `;
-
-function SelectionMenu({
-  show,
-  anchorPoint,
-}: {
-  show: boolean;
-  anchorPoint: { top: number; left: number };
-}): JSX.Element {
-  const dispatch = useDispatch();
-  return (
-    <SmallButton
-      style={{
-        top: `calc(${anchorPoint.top}px - 2.5em)`,
-        left: anchorPoint.left,
-        position: 'fixed',
-        display: show ? 'block' : 'hidden',
-        transform: 'translateX(-50%)',
-      }}
-      onClick={() => dispatch(exportSelection())}
-      primary
-    >
-      Export
-    </SmallButton>
-  );
-}
-
-function computeWordBbox(
-  content: ParagraphGeneric<TimedParagraphItem>[],
-  ref: HTMLDivElement,
-  start: number,
-  length: number
-): { top: number; bottom: number; left: number; right: number } {
-  const itemElements = ref.getElementsByClassName('item');
-  const items = new DocumentGenerator(DocumentGenerator.fromParagraphs(content).enumerate())
-    .enumerate()
-    .filter((item) => item.absoluteStart >= start && item.absoluteStart < start + length)
-    .filterMap((item) => itemElements.item(item.globalIdx) || undefined)
-    .collect();
-  const bboxes = items.map((item) => item.getBoundingClientRect());
-  const { left, right, top, bottom } = bboxes.reduce(
-    (
-      val: { top: number | null; bottom: number | null; left: number | null; right: number | null },
-      current
-    ) => {
-      if (val.bottom == null || val.bottom < current.bottom) {
-        val.bottom = current.bottom;
-      }
-      if (val.right == null || val.right < current.right) {
-        val.right = current.right;
-      }
-      if (val.top == null || val.top > current.top) {
-        val.top = current.top;
-      }
-      if (val.left == null || val.left > current.left) {
-        val.left = current.left;
-      }
-      return val;
-    },
-    { left: null, right: null, top: null, bottom: null }
-  );
-  if (left == null || right == null || top == null || bottom == null) {
-    throw new Error('bbox is null');
-  } else {
-    return { left, right, top, bottom };
-  }
-}
 
 export function Document(): JSX.Element {
   const dispatch = useDispatch();
@@ -171,23 +98,7 @@ export function Document(): JSX.Element {
   const speakerIndices = Object.fromEntries(
     Array.from(new Set(content.map((p) => p.speaker))).map((name, i) => [name, i])
   );
-  const selection = useSelector((state: RootState) => state.editor.present?.selection);
   const ref = useRef<HTMLDivElement>(null);
-  let anchorLeft = -100;
-  let anchorTop = -100;
-
-  if (selection) {
-    if (ref.current?.parentElement) {
-      const { left, right, top } = computeWordBbox(
-        content,
-        ref.current?.parentElement as HTMLDivElement,
-        selection.start,
-        selection.length
-      );
-      anchorLeft = (left + right) / 2;
-      anchorTop = top;
-    }
-  }
 
   useEffect(() => {
     ref.current && ref.current.focus();
@@ -201,7 +112,7 @@ export function Document(): JSX.Element {
       ref={ref}
     >
       <Cursor />
-      <SelectionMenu show={anchorLeft > 0} anchorPoint={{ left: anchorLeft, top: anchorTop }} />
+      <SelectionMenu documentRef={ref} content={content} />
       <FileNameDisplay path={fileName} />
 
       {content.length > 0 ? (

--- a/app/src/pages/Editor/SelectionMenu.tsx
+++ b/app/src/pages/Editor/SelectionMenu.tsx
@@ -1,0 +1,99 @@
+import { useDispatch, useSelector } from 'react-redux';
+import { SmallButton } from '../../components/Controls';
+import { exportSelection } from '../../state/editor';
+import * as React from 'react';
+import { DocumentGenerator, ParagraphGeneric, TimedParagraphItem } from '../../core/document';
+import { RootState } from '../../state';
+import { RefObject, useEffect, useState } from 'react';
+import styled from 'styled-components';
+const SelectionMenuContainer = styled.div<{ anchorTop: number; anchorLeft: number }>`
+  top: ${(props) => props.anchorTop}px;
+  left: ${(props) => props.anchorLeft}px;
+  position: absolute;
+  display: block;
+  transform: translateX(-50%) translateY(-100%);
+`;
+export function SelectionMenu({
+  documentRef,
+  content,
+}: {
+  documentRef: RefObject<HTMLDivElement>;
+  content: ParagraphGeneric<TimedParagraphItem>[];
+}): JSX.Element {
+  // we do this to re-render the cursor when the window resizes
+  const [_, setWindowSize] = useState(null as null | { height: number; width: number });
+  useEffect(() => {
+    window.addEventListener('resize', () =>
+      setWindowSize({ height: window.innerHeight, width: window.innerWidth })
+    );
+  }, []);
+  const dispatch = useDispatch();
+
+  const selection = useSelector((state: RootState) => state.editor.present?.selection);
+  if (selection) {
+    if (documentRef.current?.parentElement) {
+      const bbox = computeWordBbox(
+        content,
+        documentRef.current?.parentElement as HTMLDivElement,
+        selection.start,
+        selection.length
+      );
+      if (bbox) {
+        const { left, right, top } = bbox;
+        const anchorLeft = (left + right) / 2;
+        const anchorTop = top;
+        return (
+          <SelectionMenuContainer anchorTop={anchorTop} anchorLeft={anchorLeft}>
+            <SmallButton onClick={() => dispatch(exportSelection())} primary>
+              Export
+            </SmallButton>
+          </SelectionMenuContainer>
+        );
+      }
+    }
+  }
+  return <></>;
+}
+
+export function computeWordBbox(
+  content: ParagraphGeneric<TimedParagraphItem>[],
+  ref: HTMLDivElement,
+  start: number,
+  length: number
+): { top: number; bottom: number; left: number; right: number } | null {
+  const itemElements = ref.getElementsByClassName('item');
+  const items = DocumentGenerator.fromParagraphs(content)
+    .enumerate()
+    .filter((item) => item.absoluteStart >= start && item.absoluteStart < start + length)
+    .filterMap((item) => (itemElements.item(item.globalIdx) as HTMLElement) || undefined)
+    .collect();
+  const { left, right, top, bottom } = items.reduce(
+    (
+      val: { top: number | null; bottom: number | null; left: number | null; right: number | null },
+      current
+    ) => {
+      const bottom = current.offsetTop + current.offsetHeight;
+      const right = current.offsetLeft + current.offsetWidth;
+      if (val.bottom == null || val.bottom < bottom) {
+        val.bottom = bottom;
+      }
+      if (val.right == null || val.right < right) {
+        val.right = right;
+      }
+      if (val.top == null || val.top > current.offsetTop) {
+        val.top = current.offsetTop;
+      }
+      if (val.left == null || val.left > current.offsetLeft) {
+        val.left = current.offsetLeft;
+      }
+      return val;
+    },
+    { left: null, right: null, top: null, bottom: null }
+  );
+  if (left == null || right == null || top == null || bottom == null) {
+    console.log('bbox is null', left, right, top, bottom);
+    return null;
+  } else {
+    return { left, right, top, bottom };
+  }
+}


### PR DESCRIPTION
This commits adds a resize listener on the window to recalculate the selection menu position. It also switches to absolute positioning, so the menu is in the correct position if we scroll the document.

Fixes #85