### PR TITLE
⚡️ Speedup cursor position calculation

### DIFF
--- a/app/src/core/document.ts
+++ b/app/src/core/document.ts
@@ -340,7 +340,10 @@ export function getItemsAtTime<T extends DocumentGeneratorItem = DocumentGenerat
   generator: GeneratorBox<T>,
   time: number
 ): T[] {
+  const condition = (x: T) =>
+    x.absoluteStart - EPSILON < time && x.absoluteStart + x.length + EPSILON > time;
   return generator
-    .filter((x) => x.absoluteStart - EPSILON < time && x.absoluteStart + x.length + EPSILON > time)
+    .dropwhile((x) => !condition(x))
+    .takewhile(condition)
     .collect();
 }

--- a/app/src/util/itertools.spec.ts
+++ b/app/src/util/itertools.spec.ts
@@ -12,3 +12,26 @@ test('filter creates new iterator', () => {
   expect(secondIterator.next().value).toBe(2);
   expect(firstIterator.next().value).toBe(3);
 });
+
+test('dropuntil', () => {
+  const iter = new itertools.GeneratorBox(generator()).dropuntil((x) => x >= 2);
+  expect(iter.next().value).toBe(2);
+});
+
+test('dropwhile', () => {
+  const iter = new itertools.GeneratorBox(generator()).dropwhile((x) => x < 2);
+  expect(iter.next().value).toBe(2);
+});
+
+test('takeuntil', () => {
+  const iter = new itertools.GeneratorBox(generator()).takeuntil((x) => x >= 2);
+  expect(iter.next().value).toBe(1);
+  expect(iter.next().value).toBe(undefined);
+});
+
+test('takewhile', () => {
+  const iter = new itertools.GeneratorBox(generator()).takewhile((x) => x <= 2);
+  expect(iter.next().value).toBe(1);
+  expect(iter.next().value).toBe(2);
+  expect(iter.next().value).toBe(undefined);
+});

--- a/app/src/util/itertools.ts
+++ b/app/src/util/itertools.ts
@@ -17,6 +17,22 @@ export class GeneratorBox<T> implements Generator<T> {
     const C = Object.getPrototypeOf(this);
     return new C.constructor(filter(predicate, this));
   }
+  dropwhile(predicate: (x: T) => boolean): this {
+    const C = Object.getPrototypeOf(this);
+    return new C.constructor(dropwhile(predicate, this));
+  }
+  takewhile(predicate: (x: T) => boolean): this {
+    const C = Object.getPrototypeOf(this);
+    return new C.constructor(takewhile(predicate, this));
+  }
+  dropuntil(predicate: (x: T) => boolean): this {
+    const C = Object.getPrototypeOf(this);
+    return new C.constructor(dropuntil(predicate, this));
+  }
+  takeuntil(predicate: (x: T) => boolean): this {
+    const C = Object.getPrototypeOf(this);
+    return new C.constructor(takeuntil(predicate, this));
+  }
   enumerate(): GeneratorBox<T & { globalIdx: number }> {
     const C = Object.getPrototypeOf(this);
     return new C.constructor(enumerate(this));
@@ -80,6 +96,46 @@ function* filter<T>(predicate: (x: T) => boolean, input: Generator<T>): Generato
   for (const item of input) {
     if (predicate(item)) {
       yield item;
+    }
+  }
+}
+
+function* dropwhile<T>(predicate: (x: T) => boolean, input: Generator<T>): Generator<T> {
+  for (const item of input) {
+    if (!predicate(item)) {
+      yield item;
+      break;
+    }
+  }
+  yield* input;
+}
+
+function* dropuntil<T>(predicate: (x: T) => boolean, input: Generator<T>): Generator<T> {
+  for (const item of input) {
+    if (predicate(item)) {
+      yield item;
+      break;
+    }
+  }
+  yield* input;
+}
+
+function* takewhile<T>(predicate: (x: T) => boolean, input: Generator<T>): Generator<T> {
+  for (const item of input) {
+    if (predicate(item)) {
+      yield item;
+    } else {
+      break;
+    }
+  }
+}
+
+function* takeuntil<T>(predicate: (x: T) => boolean, input: Generator<T>): Generator<T> {
+  for (const item of input) {
+    if (!predicate(item)) {
+      yield item;
+    } else {
+      break;
     }
   }
 }


### PR DESCRIPTION
Previously we iterated through the entire document iterator on every render-frame, now we only stop once we found our items