### PR TITLE
💚 Specify macos version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ macos-latest, ubuntu-latest, windows-latest ]
+        os: [ macos-10.15, ubuntu-latest, windows-latest ]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Github changes something in the `macos-latest`-environment which broke our builds. This seems to fix it