### PR TITLE
💚 Cache entire cargo dir in ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,11 +120,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-plugins
+            ~/.cargo/
+          key: ${{ runner.os }}-cargo
 
       - uses: actions-rs/toolchain@v1
         name: Install rust


### PR DESCRIPTION
The ~/.cargo dir contains some more file cargo needs to properly run in the ci, else it will complain about pyoxidizer already being installed