### PR TITLE
🐛 (app): Disable asar-packing in releases

### DIFF
--- a/app/electron-builder.config.js
+++ b/app/electron-builder.config.js
@@ -28,6 +28,7 @@ const config = {
     category: 'Audio',
   },
   extraResources: ['./server/**', './generated/**'],
+  asar: false
 };
 
 module.exports = config;


### PR DESCRIPTION
We need ffmpeg-static to be unpacked, else the export breaks.

This PR fixes #165