### PR TITLE
speedup cursor position calculation with cache

### DIFF
--- a/app/src/pages/Editor/Cursor.tsx
+++ b/app/src/pages/Editor/Cursor.tsx
@@ -67,7 +67,7 @@ function useComputeCursorPosition(parentElement: HTMLElement | null | undefined)
   }>();
   const lastItem = last.current?.item;
 
-  if (!content || !time || !parentElement) return null;
+  if (!content || time == undefined || !parentElement) return null;
 
   if (
     !(

--- a/app/src/pages/Editor/Document.tsx
+++ b/app/src/pages/Editor/Document.tsx
@@ -97,7 +97,7 @@ export function Document(): JSX.Element {
     const parent = node?.parentElement;
     const [paragraphIdx, itemIdx] = getParagraphItemIdx(parent);
     if (paragraphIdx == content.length - 1) return false;
-    return itemIdx == content[paragraphIdx]?.content.length - 1;
+    return itemIdx == content[paragraphIdx]?.content.length - 1 && offset != 1;
   };
 
   const setBrowserRangeToStateRange = (selectionRange: globalThis.Range) => {
@@ -116,6 +116,7 @@ export function Document(): JSX.Element {
         )
           ? 4 * EPSILON
           : 0;
+
         const timeAdd = selectionRange.startOffset == nodeLength ? item.length : 0;
         dispatch(setTime(item.absoluteStart + timeAdd - timeSubtract));
       }


### PR DESCRIPTION
we could additionally add binary search instead of linear search for finding the right item in the document for reducing the time-complexity from O(n) to O(log(n)) when going over word boundries but this already catches the low-hanging fruit of reducing the time complexity while staying in the same word to O(1).