### PR TITLE
various editor improvements

### DIFF
--- a/app/src/core/document.ts
+++ b/app/src/core/document.ts
@@ -223,9 +223,7 @@ export class DocumentGenerator<
     let lastParagraph = null;
     for (const item of this) {
       const generatorItemToParagraphItem = (item: DocumentGeneratorItem): ParagraphItem => {
-        // eslint-disable-next-line unused-imports/no-unused-vars
-        const { absoluteStart, paragraphUuid, itemIdx, speaker, ...rest } = item;
-        return rest;
+        return stripParagraphItemFields(item);
       };
 
       if (lastParagraph != item.paragraphUuid) {
@@ -248,9 +246,7 @@ export class DocumentGenerator<
     let lastParagraph = null;
     for (const item of this) {
       const generatorItemToParagraphItem = (item: DocumentGeneratorItem): TimedParagraphItem => {
-        // eslint-disable-next-line unused-imports/no-unused-vars
-        const { paragraphUuid, itemIdx, speaker, ...rest } = item;
-        return rest;
+        return { ...stripParagraphItemFields(item), absoluteStart: item.absoluteStart };
       };
 
       if (lastParagraph != item.paragraphUuid) {
@@ -271,6 +267,24 @@ export class DocumentGenerator<
 
   getItemsAtTime(time: number): DocumentGeneratorItem[] {
     return getItemsAtTime(this, time);
+  }
+}
+
+function stripParagraphItemFields<T extends ParagraphItem>(x: T): ParagraphItem {
+  switch (x.type) {
+    case 'artificial_silence':
+      return { type: 'artificial_silence', length: x.length };
+    case 'silence':
+      return { type: 'silence', length: x.length, source: x.source, sourceStart: x.sourceStart };
+    case 'word':
+      return {
+        type: 'word',
+        length: x.length,
+        source: x.source,
+        sourceStart: x.sourceStart,
+        word: x.word,
+        conf: x.conf,
+      };
   }
 }
 

--- a/app/src/core/player.ts
+++ b/app/src/core/player.ts
@@ -83,11 +83,12 @@ export class Player {
   }
 
   getCurrentRenderItem(): RenderItem | undefined {
-    return this.renderItems.find(
+    const candidates = this.renderItems.filter(
       (item) =>
         item.absoluteStart <= this.currentTime &&
         item.absoluteStart + item.length >= this.currentTime
     );
+    return candidates[candidates.length - 1];
   }
 
   clampCurrentTimeToRenderItemsRange(): void {
@@ -134,6 +135,7 @@ export class Player {
     onRenderItemDone: () => void,
     onNextRenderItem: () => void
   ): void {
+    const startTime = this.currentTime;
     const lastRenderItem = this.renderItems[this.renderItems.length - 1];
     const callback = () => {
       // we clamp the result of getTime to the end of the currently played Item.
@@ -142,12 +144,14 @@ export class Player {
       this.updateCurrentTime(time);
       if (!this.playing) {
         onRenderItemDone();
-      } else if (this.currentTime >= lastRenderItem.absoluteStart + lastRenderItem.length) {
+      } else if (time >= lastRenderItem.absoluteStart + lastRenderItem.length) {
         onRenderItemDone();
         setTimeout(() => {
           this.store.dispatch(setPlay(false));
         });
       } else if (time >= renderItem.absoluteStart + renderItem.length) {
+        if (time == startTime)
+          throw new Error('something is seriously bork, playRenderItem didnt advance time');
         onRenderItemDone();
         onNextRenderItem();
       } else {

--- a/app/src/core/player.ts
+++ b/app/src/core/player.ts
@@ -45,7 +45,11 @@ export class Player {
       (state: EditorState) => state.currentTimeUserSet,
       (time) => {
         this.pause();
-        this.updateCurrentTime(time);
+
+        // we don't notify redux here of the state change because we already set the player time for user set events in the
+        // setUserSetTime action. This avoids having inconsistencies in the key repeat of the delete key.
+        this.currentTime = time;
+
         const currentRenderItem = this.getCurrentRenderItem();
 
         // we need to update this even if we are not playing because the video might be shown
@@ -132,7 +136,9 @@ export class Player {
   ): void {
     const lastRenderItem = this.renderItems[this.renderItems.length - 1];
     const callback = () => {
-      const time = getTime();
+      // we clamp the result of getTime to the end of the currently played Item.
+      // this helps to produce the expected end-state if the playing is not stopped in time.
+      const time = Math.min(getTime(), renderItem.absoluteStart + renderItem.length);
       this.updateCurrentTime(time);
       if (!this.playing) {
         onRenderItemDone();

--- a/app/src/pages/Editor/Cursor.tsx
+++ b/app/src/pages/Editor/Cursor.tsx
@@ -76,8 +76,8 @@ function useComputeCursorPosition(parentElement: HTMLElement | null | undefined)
       lastItem &&
       last.current?.content == content &&
       last.current?.parentElement == parentElement &&
-      lastItem?.absoluteStart <= time &&
-      lastItem?.absoluteStart + lastItem?.length >= time &&
+      lastItem?.absoluteStart < time &&
+      lastItem?.absoluteStart + lastItem?.length > time &&
       document.body.contains(last.current?.itemElement)
     )
   ) {

--- a/app/src/pages/Editor/Document.tsx
+++ b/app/src/pages/Editor/Document.tsx
@@ -156,6 +156,9 @@ export function Document(): JSX.Element {
       dispatch(goLeft());
     } else if (e.key == 'ArrowRight') {
       dispatch(goRight());
+    } else if (e.key == 'ArrowUp' || e.key == 'ArrowDown') {
+      // TODO: handle properly (see: https://github.com/audapolis/audapolis/issues/228)
+      e.preventDefault();
     }
   };
   function getSpeakerColor(speaker: string) {

--- a/app/src/state/editor/edit.spec.ts
+++ b/app/src/state/editor/edit.spec.ts
@@ -1,0 +1,331 @@
+import { paste } from './edit';
+import { emptyDocument, Paragraph } from '../../core/document';
+import { editorDefaults, EditorState } from './types';
+import { assertSome, EPSILON } from '../../util';
+
+const testContent: Paragraph[] = [
+  {
+    speaker: 'paragraph_01',
+    content: [
+      { type: 'artificial_silence', length: 1 },
+      { type: 'artificial_silence', length: 1 },
+      { type: 'artificial_silence', length: 1 },
+    ],
+  },
+  {
+    speaker: 'paragraph_02',
+    content: [
+      { type: 'artificial_silence', length: 1 },
+      { type: 'artificial_silence', length: 1 },
+      { type: 'artificial_silence', length: 1 },
+    ],
+  },
+];
+
+test('test paste merge', () => {
+  const state: EditorState = {
+    ...editorDefaults,
+    document: { ...emptyDocument, content: JSON.parse(JSON.stringify(testContent)) },
+    currentTimePlayer: 1.0,
+  };
+  assertSome(paste.reducers);
+  assertSome(paste.reducers.fulfilled);
+  paste.reducers.fulfilled(state, {
+    ...emptyDocument,
+    content: [
+      {
+        speaker: 'paragraph_01',
+        content: [
+          { type: 'artificial_silence', length: 1 },
+          { type: 'artificial_silence', length: 1 },
+          { type: 'artificial_silence', length: 1 },
+        ],
+      },
+    ],
+  });
+  expect(state.document.content).toMatchObject([
+    {
+      speaker: 'paragraph_01',
+      content: [
+        { type: 'artificial_silence', length: 1 },
+        { type: 'artificial_silence', length: 1 },
+        { type: 'artificial_silence', length: 1 },
+        { type: 'artificial_silence', length: 1 },
+        { type: 'artificial_silence', length: 1 },
+        { type: 'artificial_silence', length: 1 },
+      ],
+    },
+    {
+      speaker: 'paragraph_02',
+      content: [
+        { type: 'artificial_silence', length: 1 },
+        { type: 'artificial_silence', length: 1 },
+        { type: 'artificial_silence', length: 1 },
+      ],
+    },
+  ]);
+});
+test('test paste non-merge', () => {
+  const state: EditorState = {
+    ...editorDefaults,
+    document: { ...emptyDocument, content: JSON.parse(JSON.stringify(testContent)) },
+    currentTimePlayer: 1.0,
+  };
+  assertSome(paste.reducers);
+  assertSome(paste.reducers.fulfilled);
+  paste.reducers.fulfilled(state, {
+    ...emptyDocument,
+    content: [
+      {
+        speaker: 'paragraph_02',
+        content: [
+          { type: 'artificial_silence', length: 1 },
+          { type: 'artificial_silence', length: 1 },
+          { type: 'artificial_silence', length: 1 },
+        ],
+      },
+    ],
+  });
+  expect(state.document.content).toMatchObject([
+    {
+      speaker: 'paragraph_01',
+      content: [{ type: 'artificial_silence', length: 1 }],
+    },
+    {
+      speaker: 'paragraph_02',
+      content: [
+        { type: 'artificial_silence', length: 1 },
+        { type: 'artificial_silence', length: 1 },
+        { type: 'artificial_silence', length: 1 },
+      ],
+    },
+    {
+      speaker: 'paragraph_01',
+      content: [
+        { type: 'artificial_silence', length: 1 },
+        { type: 'artificial_silence', length: 1 },
+      ],
+    },
+    {
+      speaker: 'paragraph_02',
+      content: [
+        { type: 'artificial_silence', length: 1 },
+        { type: 'artificial_silence', length: 1 },
+        { type: 'artificial_silence', length: 1 },
+      ],
+    },
+  ]);
+});
+
+test('test paste merge end of paragraph', () => {
+  const state: EditorState = {
+    ...editorDefaults,
+    document: {
+      ...emptyDocument,
+      content: [
+        {
+          speaker: 'paragraph_01',
+          content: [
+            { type: 'word', length: 1, source: '', sourceStart: 0, word: '', conf: 1 },
+            { type: 'word', length: 1, source: '', sourceStart: 1, word: '', conf: 1 },
+            { type: 'word', length: 1, source: '', sourceStart: 2, word: '', conf: 1 },
+          ],
+        },
+        {
+          speaker: 'paragraph_01',
+          content: [
+            { type: 'word', length: 1, source: '', sourceStart: 0, word: '', conf: 1 },
+            { type: 'word', length: 1, source: '', sourceStart: 1, word: '', conf: 1 },
+            { type: 'word', length: 1, source: '', sourceStart: 2, word: '', conf: 1 },
+          ],
+        },
+      ],
+    },
+    currentTimePlayer: 3.0 - EPSILON,
+  };
+  assertSome(paste.reducers);
+  assertSome(paste.reducers.fulfilled);
+  paste.reducers.fulfilled(state, {
+    ...emptyDocument,
+    content: [
+      {
+        speaker: 'paragraph_01',
+        content: [{ type: 'word', length: 1, source: '', sourceStart: 3, word: '', conf: 1 }],
+      },
+    ],
+  });
+  expect(state.document.content).toMatchObject([
+    {
+      speaker: 'paragraph_01',
+      content: [
+        { type: 'word', length: 1, source: '', sourceStart: 0, word: '', conf: 1 },
+        { type: 'word', length: 1, source: '', sourceStart: 1, word: '', conf: 1 },
+        { type: 'word', length: 1, source: '', sourceStart: 2, word: '', conf: 1 },
+        { type: 'word', length: 1, source: '', sourceStart: 3, word: '', conf: 1 },
+      ],
+    },
+    {
+      speaker: 'paragraph_01',
+      content: [
+        { type: 'word', length: 1, source: '', sourceStart: 0, word: '', conf: 1 },
+        { type: 'word', length: 1, source: '', sourceStart: 1, word: '', conf: 1 },
+        { type: 'word', length: 1, source: '', sourceStart: 2, word: '', conf: 1 },
+      ],
+    },
+  ]);
+});
+test('test paste merge start of paragraph', () => {
+  const state: EditorState = {
+    ...editorDefaults,
+    document: {
+      ...emptyDocument,
+      content: [
+        {
+          speaker: 'paragraph_01',
+          content: [
+            { type: 'word', length: 1, source: '', sourceStart: 0, word: '', conf: 1 },
+            { type: 'word', length: 1, source: '', sourceStart: 1, word: '', conf: 1 },
+            { type: 'word', length: 1, source: '', sourceStart: 2, word: '', conf: 1 },
+          ],
+        },
+        {
+          speaker: 'paragraph_01',
+          content: [
+            { type: 'word', length: 1, source: '', sourceStart: 0, word: '', conf: 1 },
+            { type: 'word', length: 1, source: '', sourceStart: 1, word: '', conf: 1 },
+            { type: 'word', length: 1, source: '', sourceStart: 2, word: '', conf: 1 },
+          ],
+        },
+      ],
+    },
+    currentTimePlayer: 3.0,
+  };
+  assertSome(paste.reducers);
+  assertSome(paste.reducers.fulfilled);
+  paste.reducers.fulfilled(state, {
+    ...emptyDocument,
+    content: [
+      {
+        speaker: 'paragraph_01',
+        content: [{ type: 'word', length: 1, source: '', sourceStart: 3, word: '', conf: 1 }],
+      },
+    ],
+  });
+  expect(state.document.content).toMatchObject([
+    {
+      speaker: 'paragraph_01',
+      content: [
+        { type: 'word', length: 1, source: '', sourceStart: 0, word: '', conf: 1 },
+        { type: 'word', length: 1, source: '', sourceStart: 1, word: '', conf: 1 },
+        { type: 'word', length: 1, source: '', sourceStart: 2, word: '', conf: 1 },
+      ],
+    },
+    {
+      speaker: 'paragraph_01',
+      content: [
+        { type: 'word', length: 1, source: '', sourceStart: 3, word: '', conf: 1 },
+        { type: 'word', length: 1, source: '', sourceStart: 0, word: '', conf: 1 },
+        { type: 'word', length: 1, source: '', sourceStart: 1, word: '', conf: 1 },
+        { type: 'word', length: 1, source: '', sourceStart: 2, word: '', conf: 1 },
+      ],
+    },
+  ]);
+});
+
+test('test paste beginning', () => {
+  const state: EditorState = {
+    ...editorDefaults,
+    document: {
+      ...emptyDocument,
+      content: [
+        {
+          speaker: 'paragraph_01',
+          content: [
+            { type: 'word', length: 1, source: '', sourceStart: 0, word: '', conf: 1 },
+            { type: 'word', length: 1, source: '', sourceStart: 1, word: '', conf: 1 },
+            { type: 'word', length: 1, source: '', sourceStart: 2, word: '', conf: 1 },
+          ],
+        },
+      ],
+    },
+    currentTimePlayer: 0,
+  };
+  assertSome(paste.reducers);
+  assertSome(paste.reducers.fulfilled);
+  paste.reducers.fulfilled(state, {
+    ...emptyDocument,
+    content: [
+      {
+        speaker: 'paragraph_01',
+        content: [{ type: 'word', length: 1, source: '', sourceStart: 3, word: '', conf: 1 }],
+      },
+    ],
+  });
+  expect(state.document.content).toMatchObject([
+    {
+      speaker: 'paragraph_01',
+      content: [
+        { type: 'word', length: 1, source: '', sourceStart: 3, word: '', conf: 1 },
+        { type: 'word', length: 1, source: '', sourceStart: 0, word: '', conf: 1 },
+        { type: 'word', length: 1, source: '', sourceStart: 1, word: '', conf: 1 },
+        { type: 'word', length: 1, source: '', sourceStart: 2, word: '', conf: 1 },
+      ],
+    },
+  ]);
+});
+test('test paste end', () => {
+  const state: EditorState = {
+    ...editorDefaults,
+    document: {
+      ...emptyDocument,
+      content: [
+        {
+          speaker: 'paragraph_01',
+          content: [
+            { type: 'word', length: 1, source: '', sourceStart: 0, word: '', conf: 1 },
+            { type: 'word', length: 1, source: '', sourceStart: 1, word: '', conf: 1 },
+            { type: 'word', length: 1, source: '', sourceStart: 2, word: '', conf: 1 },
+          ],
+        },
+      ],
+    },
+    currentTimePlayer: 3.0,
+  };
+  assertSome(paste.reducers);
+  assertSome(paste.reducers.fulfilled);
+  paste.reducers.fulfilled(state, {
+    ...emptyDocument,
+    content: [
+      {
+        speaker: 'paragraph_01',
+        content: [{ type: 'word', length: 1, source: '', sourceStart: 3, word: '', conf: 1 }],
+      },
+    ],
+  });
+  expect(state.document.content).toMatchObject([
+    {
+      speaker: 'paragraph_01',
+      content: [
+        { type: 'word', length: 1, source: '', sourceStart: 0, word: '', conf: 1 },
+        { type: 'word', length: 1, source: '', sourceStart: 1, word: '', conf: 1 },
+        { type: 'word', length: 1, source: '', sourceStart: 2, word: '', conf: 1 },
+        { type: 'word', length: 1, source: '', sourceStart: 3, word: '', conf: 1 },
+      ],
+    },
+  ]);
+});
+
+test('test paste empty', () => {
+  const state: EditorState = {
+    ...editorDefaults,
+    document: {
+      ...emptyDocument,
+      content: JSON.parse(JSON.stringify(testContent)),
+    },
+    currentTimePlayer: 2,
+  };
+  assertSome(paste.reducers);
+  assertSome(paste.reducers.fulfilled);
+  paste.reducers.fulfilled(state, emptyDocument);
+  expect(state.document.content).toMatchObject(testContent);
+});

--- a/app/src/state/editor/edit.ts
+++ b/app/src/state/editor/edit.ts
@@ -13,6 +13,7 @@ import { clipboard } from 'electron';
 import { createActionWithReducer, createAsyncActionWithReducer } from '../util';
 import { EditorState } from './types';
 import { selectLeft } from './selection';
+import { setUserSetTime } from './play';
 
 export const insertParagraphBreak = createActionWithReducer<EditorState>(
   'editor/insertParagraphBreak',
@@ -70,7 +71,7 @@ export const deleteSelection = createActionWithReducer<EditorState>(
     state.document.content = DocumentGenerator.fromParagraphs(state.document.content)
       .filter(isNotSelected)
       .toParagraphs();
-    state.currentTimeUserSet = selection.range.start;
+    setUserSetTime.reducer(state, selection.range.start);
     state.selection = null;
   }
 );

--- a/app/src/state/editor/index.ts
+++ b/app/src/state/editor/index.ts
@@ -37,17 +37,7 @@ function editorReducer(state: EditorState | undefined, action: AnyAction): Edito
 
   return produce(state, (draft) => {
     reducers.forEach((reducer) => {
-      if ('reducer' in reducer) {
-        if (reducer.type == action.type) {
-          reducer.reducer(draft, action.payload);
-        }
-      } else {
-        Object.entries(reducer.reducers).forEach(([actionType, reducer]) => {
-          if (actionType == action.type) {
-            reducer(draft, action.payload);
-          }
-        });
-      }
+      reducer.handleAction(draft, action);
     });
   });
 }

--- a/app/src/state/editor/io.ts
+++ b/app/src/state/editor/io.ts
@@ -66,7 +66,7 @@ export const closeDocument = createAsyncActionWithReducer<EditorState>(
 );
 
 export const setSources = createActionWithReducer<EditorState, Record<string, Source>>(
-  'editor/setState',
+  'editor/setSources',
   (state, sources) => {
     state.document.sources = sources;
   }

--- a/app/src/state/editor/play.ts
+++ b/app/src/state/editor/play.ts
@@ -14,6 +14,10 @@ export const setUserSetTime = createActionWithReducer<EditorState, number>(
   'editor/setTimeUserSet',
   (state, newTime) => {
     state.currentTimeUserSet = newTime;
+
+    // we also set the player time here (instead of in the player) because this way we cannot come into an
+    // inconsistent state when fast events are fired (e.g. key repeat of the backspace key)
+    state.currentTimePlayer = newTime;
   }
 );
 
@@ -43,9 +47,9 @@ export const goLeft = createActionWithReducer<EditorState>('editor/goLeft', (sta
 
   // if we are at the beginning of a paragraph, we should put the cursor at the end of the previous paragraph
   if (items.length == 2 && secondItem.firstInParagraph) {
-    state.currentTimeUserSet = firstItem.absoluteStart + firstItem.length - 2 * EPSILON;
+    setUserSetTime.reducer(state, firstItem.absoluteStart + firstItem.length - 2 * EPSILON);
   } else {
-    state.currentTimeUserSet = firstItem.absoluteStart;
+    setUserSetTime.reducer(state, firstItem.absoluteStart);
   }
   state.selection = null;
 });
@@ -60,9 +64,9 @@ export const goRight = createActionWithReducer<EditorState>('editor/goRight', (s
   assertSome(secondItem);
 
   if (items.length == 2 && secondItem.lastInParagraph) {
-    state.currentTimeUserSet = secondItem.absoluteStart + secondItem.length - 2 * EPSILON;
+    setUserSetTime.reducer(state, secondItem.absoluteStart + secondItem.length - 2 * EPSILON);
   } else {
-    state.currentTimeUserSet = secondItem.absoluteStart + secondItem.length;
+    setUserSetTime.reducer(state, secondItem.absoluteStart + secondItem.length);
   }
   state.selection = null;
 });

--- a/app/src/state/editor/selection.spec.ts
+++ b/app/src/state/editor/selection.spec.ts
@@ -1,6 +1,6 @@
 import { editorDefaults, EditorState, Range } from './types';
 import { DocumentGenerator, emptyDocument, getItemsAtTime, Paragraph } from '../../core/document';
-import { selectLeft, selectRight } from './selection';
+import { selectionIncludeFully, selectLeft, selectRight } from './selection';
 import { EPSILON } from '../../util';
 
 const testContent: Paragraph[] = [
@@ -116,4 +116,35 @@ test('selectLeft shrink ltr selection', () => {
 });
 test('selectRight convert ltr to non-ltr', () => {
   testLeft({ start: 1, length: 1, ltr: true }, { start: 0, length: 2, ltr: false });
+});
+
+const testSelectionIncludeFully = (
+  before: DirectionalRange | number,
+  itemIndex: number,
+  after: DirectionalRange
+) => {
+  const state = JSON.parse(JSON.stringify(testState));
+  if (typeof before == 'number') {
+    state.currentTimePlayer = before;
+  } else {
+    state.selection = directionalRangeToSelection(before);
+  }
+  const item = DocumentGenerator.fromParagraphs(testContent).collect()[itemIndex];
+
+  selectionIncludeFully.reducer(state, item);
+  expect(state.selection).toMatchObject(directionalRangeToSelection(after));
+};
+test('selectionIncludeFully ltr', () => {
+  testSelectionIncludeFully({ start: 1, length: 1, ltr: true }, 3, {
+    start: 1,
+    length: 3,
+    ltr: true,
+  });
+});
+test('selectionIncludeFully non-ltr', () => {
+  testSelectionIncludeFully({ start: 2, length: 1, ltr: false }, 0, {
+    start: 0,
+    length: 3,
+    ltr: false,
+  });
 });

--- a/app/src/state/editor/selection.spec.ts
+++ b/app/src/state/editor/selection.spec.ts
@@ -1,0 +1,119 @@
+import { editorDefaults, EditorState, Range } from './types';
+import { DocumentGenerator, emptyDocument, getItemsAtTime, Paragraph } from '../../core/document';
+import { selectLeft, selectRight } from './selection';
+import { EPSILON } from '../../util';
+
+const testContent: Paragraph[] = [
+  {
+    speaker: 'paragraph_01',
+    content: [
+      { type: 'artificial_silence', length: 1 },
+      { type: 'artificial_silence', length: 1 },
+      { type: 'artificial_silence', length: 1 },
+    ],
+  },
+  {
+    speaker: 'paragraph_02',
+    content: [
+      { type: 'artificial_silence', length: 1 },
+      { type: 'artificial_silence', length: 1 },
+      { type: 'artificial_silence', length: 1 },
+    ],
+  },
+];
+
+const testState: EditorState = {
+  ...editorDefaults,
+  document: {
+    ...emptyDocument,
+    content: testContent,
+  },
+};
+
+type DirectionalRange = Range & { ltr: boolean };
+const directionalRangeToSelection = (directionalRange: DirectionalRange) => {
+  const startTime = directionalRange.start + (directionalRange.ltr ? 0 : directionalRange.length);
+  const startItems = getItemsAtTime(DocumentGenerator.fromParagraphs(testContent), startTime);
+  // eslint-disable-next-line unused-imports/no-unused-vars
+  const { paragraphUuid, ...startItem } =
+    startItems[directionalRange.ltr ? startItems.length - 1 : 0];
+
+  return {
+    range: {
+      start: directionalRange.start,
+      length: directionalRange.length,
+    },
+    startItem: startItem,
+  };
+};
+
+const testRight = (before: DirectionalRange | number, after: DirectionalRange) => {
+  const state = JSON.parse(JSON.stringify(testState));
+  if (typeof before == 'number') {
+    state.currentTimePlayer = before;
+  } else {
+    state.selection = directionalRangeToSelection(before);
+  }
+  selectRight.reducer(state);
+  expect(state.selection).toMatchObject(directionalRangeToSelection(after));
+};
+
+test('selectRight start selection at 0', () => {
+  testRight(0, { start: 0, length: 1, ltr: true });
+});
+test('selectRight start selection at 0.4', () => {
+  testRight(0.4, { start: 0, length: 1, ltr: true });
+});
+test('selectRight start selection at 0.6', () => {
+  testRight(0.6, { start: 0, length: 1, ltr: true });
+});
+test('selectRight start selection at 1', () => {
+  testRight(1, { start: 1, length: 1, ltr: true });
+});
+test('selectRight start selection at end of paragraph', () => {
+  testRight(3 - EPSILON, { start: 3, length: 1, ltr: true });
+});
+
+test('selectRight extend ltr selection', () => {
+  testRight({ start: 1, length: 1, ltr: true }, { start: 1, length: 2, ltr: true });
+});
+test('selectRight shrink non-ltr selection', () => {
+  testRight({ start: 1, length: 2, ltr: false }, { start: 2, length: 1, ltr: false });
+});
+test('selectRight convert non-ltr to ltr', () => {
+  testRight({ start: 1, length: 1, ltr: false }, { start: 1, length: 2, ltr: true });
+});
+
+const testLeft = (before: DirectionalRange | number, after: DirectionalRange) => {
+  const state = JSON.parse(JSON.stringify(testState));
+  if (typeof before == 'number') {
+    state.currentTimePlayer = before;
+  } else {
+    state.selection = directionalRangeToSelection(before);
+  }
+  selectLeft.reducer(state);
+  expect(state.selection).toMatchObject(directionalRangeToSelection(after));
+};
+
+test('selectLeft start selection at 0', () => {
+  testLeft(0, { start: 0, length: 1, ltr: false });
+});
+test('selectLeft start selection at 1', () => {
+  testLeft(1, { start: 0, length: 1, ltr: false });
+});
+test('selectLeft start selection at 2', () => {
+  testLeft(2, { start: 1, length: 1, ltr: false });
+});
+test('selectLeft start selection at end of paragraph', () => {
+  testLeft(3 - EPSILON, { start: 2, length: 1, ltr: false });
+});
+
+test('selectLeft extend non-ltr selection', () => {
+  testLeft({ start: 1, length: 1, ltr: false }, { start: 0, length: 2, ltr: false });
+});
+test('selectLeft shrink ltr selection', () => {
+  testLeft({ start: 1, length: 2, ltr: true }, { start: 1, length: 1, ltr: false });
+});
+test('selectRight convert ltr to non-ltr', () => {
+  testLeft({ start: 1, length: 1, ltr: true }, { start: 0, length: 2, ltr: false });
+});

--- a/app/src/state/editor/selection.ts
+++ b/app/src/state/editor/selection.ts
@@ -43,7 +43,14 @@ export const selectRight = createActionWithReducer<EditorState>('editor/selectRi
     return items[items.length - 1];
   };
   if (!selectionInfo || !state.selection) {
-    const item = getItemRight(state.currentTimePlayer);
+    let item = getItemRight(state.currentTimePlayer);
+
+    // this is special handling for the case where we are at the end of a paragraph
+    // and position the cursor -EPSILON from the end of the item
+    if (item.absoluteStart + item.length - state.currentTimePlayer < 2 * EPSILON) {
+      item = getItemRight(item.absoluteStart + item.length);
+    }
+
     state.selection = {
       range: { start: item.absoluteStart, length: item.length },
       startItem: item,

--- a/app/src/state/util.ts
+++ b/app/src/state/util.ts
@@ -1,22 +1,34 @@
 import { Draft } from 'immer';
-import { AsyncThunk, createAsyncThunk } from '@reduxjs/toolkit';
+import { AnyAction, AsyncThunk, createAsyncThunk } from '@reduxjs/toolkit';
 import { AsyncThunkPayloadCreator } from '@reduxjs/toolkit/dist/createAsyncThunk';
 import { RootState } from './index';
 
 type ReducerType<StateSlice, Payload = void> = (state: Draft<StateSlice>, payload: Payload) => void;
 
-type PayloadActionCreator<Payload> = (payload: Payload) => { type: string; payload: Payload };
-export type ActionWithReducers<StateSlice, Payload> = PayloadActionCreator<Payload> & {
-  reducer: ReducerType<StateSlice, Payload>;
-  type: string;
+// for consumption by the top level reducer
+type ReducerApi<StateSlice> = {
+  handleAction: ReducerType<StateSlice, AnyAction>;
 };
+
+type PayloadActionCreator<Payload> = (payload: Payload) => { type: string; payload: Payload };
+export type ActionWithReducers<StateSlice, Payload> = PayloadActionCreator<Payload> &
+  ReducerApi<StateSlice> & {
+    reducer: ReducerType<StateSlice, Payload>;
+    type: string;
+  };
+
 export type AsyncActionWithReducers<StateSlice, Returned, ThunkArg> = AsyncThunk<
   Returned,
   ThunkArg,
   Record<string, never>
-> & {
-  reducers: { [x: string]: ReducerType<StateSlice, Returned | Error | void> };
-};
+> &
+  ReducerApi<StateSlice> & {
+    reducers?: {
+      pending?: ReducerType<StateSlice, void>;
+      rejected?: ReducerType<StateSlice, Error>;
+      fulfilled?: ReducerType<StateSlice, Returned>;
+    };
+  };
 
 /**
  * This function creates a special type that is both an action creator and contains the corresponding reducer for these actions.
@@ -35,36 +47,46 @@ export function createActionWithReducer<StateSlice, Payload = void>(
   reducer: ReducerType<StateSlice, Payload>
 ): ActionWithReducers<StateSlice, Payload> {
   const actionCreator: PayloadActionCreator<Payload> = (payload) => ({ type, payload });
-  return Object.assign(actionCreator, { reducer, type });
+  const handleAction: ReducerType<StateSlice, AnyAction> = (state, action) => {
+    if (action.type == type) reducer(state, action.payload);
+  };
+  return Object.assign(actionCreator, { reducer, handleAction, type });
 }
 
 /**
  * this function works analogous to the way the `createActionReducerPair` function works. the difference is that this
  * function also gets an async thunk function as a argument, so it behaves like an async thunk. the
- * `thunk.rejected`, `thunk.fulfilled`, and `thunk.pending` actions can be handled in the reducer object and are thus
+ * `thunk.rejected`, `thunk.fulfilled`, and `thunk.pending` actions can be handled in the reducers object and are thus
  * called after the thunk code.
  * Beware: Even if you theoretically can dispatch other actions and get the full state in your thunk code, this is a
  * potential foot-gun as you could violate atomicity guarantees in a non-obvious way.
  *
  * @param type the string uniquely identifying the action
  * @param payloadCreator the async function creating the action
- * @param reducer the reducer associated with this action
+ * @param reducers the reducers associated with this action
  */
 export function createAsyncActionWithReducer<StateSlice, ThunkArg = void, Returned = void>(
   type: string,
   payloadCreator: AsyncThunkPayloadCreator<Returned, ThunkArg, { state: RootState }>,
-  reducer?: {
+  reducers?: {
     pending?: ReducerType<StateSlice>;
-    rejected?: (state: Draft<StateSlice>, error: Error) => void;
+    rejected?: ReducerType<StateSlice, Error>;
     fulfilled?: ReducerType<StateSlice, Returned>;
   }
 ): AsyncActionWithReducers<StateSlice, Returned, ThunkArg> {
   const thunk = createAsyncThunk<Returned, ThunkArg>(type, payloadCreator);
-  const reducers: { [x: string]: ReducerType<StateSlice, Returned | Error | void> } = {};
 
-  if (reducer?.pending) reducers[thunk.pending.type] = reducer.pending;
-  if (reducer?.rejected) reducers[thunk.rejected.type] = reducer.rejected;
-  if (reducer?.fulfilled) reducers[thunk.fulfilled.type] = reducer.fulfilled;
+  const handleAction: ReducerType<StateSlice, AnyAction> = (state, action) => {
+    if (reducers) {
+      if (reducers.pending && action.type == thunk.pending.type) {
+        reducers.pending(state);
+      } else if (reducers.rejected && action.type == thunk.rejected.type) {
+        reducers.rejected(state, action.payload);
+      } else if (reducers.fulfilled && action.type == thunk.fulfilled.type) {
+        reducers.fulfilled(state, action.payload);
+      }
+    }
+  };
 
-  return Object.assign(thunk, { reducers });
+  return Object.assign(thunk, { reducers, handleAction });
 }


### PR DESCRIPTION
- 🧪️ add tests for editor.go{Left,Right}
- 🧪️ add tests for editor.selectionIncludeFully
- 🐛️ fix cursor cache invalidation
- 🐛️ prevent default actions on Arrow{Up,Down}
- 🐛️ fix handling of key-repeated delete
- 🐛️ fix playback on exportItem boundaries
- ♻️ change api for create{Async,}ActionWithReducer
- 🤯️ paste into current paragraph when same speaker
