### PR TITLE
👷 Enable cross platform contributions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Import and trust codesigning cert
-        if: startsWith(matrix.os, 'macos')
+        if: startsWith(matrix.os, 'macos') && (github.ref_name == 'main' || github.ref_type == 'tag')
         shell: bash
         run: ./.github/workflows/import_cert.sh
         env:

--- a/app/package.json
+++ b/app/package.json
@@ -24,7 +24,7 @@
     "check": "npm-run-all --continue-on-error check:*",
     "check:tsc": "tsc --noEmit --incremental",
     "check:eslint": "eslint --ext .ts,.tsx . --cache",
-    "fmt": "prettier --write '{src,main_process}/**/*'"
+    "fmt": "prettier --write \"{src,main_process}/**/*\""
   },
   "keywords": [],
   "license": "AGPL-3.0",

--- a/app/scripts/generate_licenses.mjs
+++ b/app/scripts/generate_licenses.mjs
@@ -1,6 +1,6 @@
 import JSZip from 'jszip';
-import nlf from "nlf";
-import fs from "fs";
+import nlf from 'nlf';
+import fs from 'fs';
 
 const args = process.argv.slice(2);
 
@@ -48,8 +48,8 @@ nlf.find({}, function (err, data) {
   }
   let total = license_parts.join('\n\n');
   const zip = new JSZip();
-  zip.file("licenses.txt", total);
-  zip.generateAsync({type:"nodebuffer"}).then((buf) => {
-    fs.writeFileSync(args[0], buf)
+  zip.file('licenses.txt', total);
+  zip.generateAsync({ type: 'nodebuffer' }).then((buf) => {
+    fs.writeFileSync(args[0], buf);
   });
 });


### PR DESCRIPTION
When setting up the repo in Windows, I ran into some initial problems.

commit#1 resolves the most important of those (`fmt`-script crashing), and should have no impact for Mac/Linux users. Please verify if you are unsure!
commit#2 is the result of running `prettier --write *` (ignoring .json, .md and extensionless files) in `/app`, which was required to avoid a heap of prettier-warnings. It just so happened that it caught some code not aligned with the prettier rules on the way.

I would suggest that moving forward, the `fmt`-script should also include `/ipc`, `/scripts` and all root-level `.js`-files to avoid similar issues/nuisances in the future. If you as maintainers agree, I can include that as a third commit in this same pull request.