### PR TITLE
🐛 Handle export crashes

### DIFF
--- a/app/src/pages/Editor/ExportDocumentDialog.tsx
+++ b/app/src/pages/Editor/ExportDocumentDialog.tsx
@@ -56,9 +56,11 @@ export function ExportDocumentDialog(): JSX.Element {
       const state: RootState = store.getState();
       dispatch(setExportState({ running: true, progress: 0 }));
       assertSome(state.editor.present);
-      await exportFnRef.current(state.editor.present.document, formState.path, (p) => {
-        dispatch(setExportState({ running: true, progress: p }));
-      });
+      await exportFnRef
+        .current(state.editor.present.document, formState.path, (p) => {
+          dispatch(setExportState({ running: true, progress: p }));
+        })
+        .finally(() => dispatch(setExportState({ running: false, progress: 1 })));
     };
 
     toast


### PR DESCRIPTION
Until now, if an export crashed, it was no longer possible to export the file again.