### PR TITLE
🖱️ set focus on mouse click to document

### DIFF
--- a/app/src/pages/Editor/Document.tsx
+++ b/app/src/pages/Editor/Document.tsx
@@ -63,7 +63,10 @@ export function Document(): JSX.Element {
 
   const mouseDownHandler: MouseEventHandler = (e) => {
     if (e.detail != 1) return;
+
     e.preventDefault();
+    ref.current?.focus(); // sometimes we loose focus and then it is nice to be able to gain it back
+
     if (e.detail == 1 && !e.shiftKey) {
       handleWordClick(dispatch, content, e);
     } else if (e.detail == 1 && e.shiftKey) {


### PR DESCRIPTION
Previously it was hard to regain focus when the document lost it. This makes this easier (just click on the document)
