### PR TITLE
🐛 Do not allow selection to be outside document

### DIFF
--- a/app/src/state/editor/selection.spec.ts
+++ b/app/src/state/editor/selection.spec.ts
@@ -145,6 +145,21 @@ test('moveSelectionHeadLeft: at idx=0 is noop', () => {
   expect(state.cursor.userIndex).toBe(0);
 });
 
+test('moveSelectionHeadLeft: does not extend beyond document', () => {
+  const state = _.cloneDeep(testState);
+  state.cursor.current = 'user';
+  state.cursor.userIndex = 2;
+  state.selection = { headPosition: 'left', startIndex: 2, length: 1 };
+  moveSelectionHeadLeft.reducer(state);
+  expect(state.selection).toStrictEqual({ headPosition: 'left', startIndex: 1, length: 2 });
+  expect(state.cursor.current).toBe('user');
+  expect(state.cursor.userIndex).toBe(1);
+  moveSelectionHeadLeft.reducer(state);
+  expect(state.selection).toStrictEqual({ headPosition: 'left', startIndex: 1, length: 2 });
+  expect(state.cursor.current).toBe('user');
+  expect(state.cursor.userIndex).toBe(1);
+});
+
 // move head right
 
 test('moveSelectionHeadRight: no selection, selects item right of cursor', () => {
@@ -256,6 +271,29 @@ test('moveSelectionHeadRight: multiple para breaks to right', () => {
   expect(state.selection).toStrictEqual({ headPosition: 'right', startIndex: 3, length: 2 });
   expect(state.cursor.current).toBe('user');
   expect(state.cursor.userIndex).toBe(5);
+});
+
+test('moveSelectionHeadRight: does not extend beyond document', () => {
+  const state = _.cloneDeep(testState);
+  state.cursor.current = 'user';
+  state.cursor.userIndex = 6;
+  state.selection = { headPosition: 'right', startIndex: 5, length: 1 };
+  moveSelectionHeadRight.reducer(state);
+  expect(state.selection).toStrictEqual({
+    headPosition: 'right',
+    startIndex: 5,
+    length: 2,
+  });
+  expect(state.cursor.current).toBe('user');
+  expect(state.cursor.userIndex).toBe(7);
+  moveSelectionHeadRight.reducer(state);
+  expect(state.selection).toStrictEqual({
+    headPosition: 'right',
+    startIndex: 5,
+    length: 2,
+  });
+  expect(state.cursor.current).toBe('user');
+  expect(state.cursor.userIndex).toBe(7);
 });
 
 // selectAll

--- a/app/src/state/editor/selection.ts
+++ b/app/src/state/editor/selection.ts
@@ -10,7 +10,12 @@
 import { assertSome } from '../../util';
 import { createActionWithReducer } from '../util';
 import { EditorState, Selection } from './types';
-import { currentIndex, currentIndexLeft, memoizedTimedDocumentItems } from './selectors';
+import {
+  currentIndex,
+  currentIndexLeft,
+  firstPossibleCursorPosition,
+  memoizedTimedDocumentItems,
+} from './selectors';
 
 export const setSelection = createActionWithReducer<EditorState, Selection | null>(
   'editor/setSelection',
@@ -35,6 +40,9 @@ function setCursorToSelectionHead(state: EditorState) {
 export const moveSelectionHeadLeft = createActionWithReducer<EditorState>(
   'editor/moveSelectionHeadLeft',
   (state) => {
+    if (currentIndexLeft(state) < firstPossibleCursorPosition(state.document.content)) {
+      return;
+    }
     if (state.selection !== null) {
       changeSelectionHeadLeft(state);
     } else {
@@ -72,6 +80,9 @@ function createSelectionLeft(state: EditorState) {
 export const moveSelectionHeadRight = createActionWithReducer<EditorState>(
   'editor/moveSelectionHeadRight',
   (state) => {
+    if (currentIndex(state) + 1 >= state.document.content.length) {
+      return;
+    }
     if (state.selection) {
       changeSelectionHeadRight(state);
     } else {


### PR DESCRIPTION
If the selection head is on the left end of the document, we cannot move if further to the left. Same on the right end

Fixed #324 