### PR TITLE
🐛 Run log arguments to string conversion before ipc

### DIFF
--- a/app/ipc/ipc_main.ts
+++ b/app/ipc/ipc_main.ts
@@ -100,5 +100,5 @@ ipcMain.handle('get-home-path', () => {
 
 ipcMain.handle('log-line', (_event, source: LogSource, level: LogLevel, ...args: any[]) => {
   assertSome(logLine);
-  logLine(source, level, ...args);
+  logLine(source, level, ...args.map((x) => JSON.stringify(x)));
 });

--- a/app/ipc/ipc_renderer.ts
+++ b/app/ipc/ipc_renderer.ts
@@ -78,5 +78,10 @@ export function subscribeExportDebugLog(
 }
 
 export function sendLogLine(level: LogLevel, ...args: any[]): void {
-  ipcRenderer.invoke('log-line', LogSource.RendererProcess, level, args);
+  ipcRenderer.invoke(
+    'log-line',
+    LogSource.RendererProcess,
+    level,
+    ...args.map((x) => x?.toString() || 'n/a')
+  );
 }


### PR DESCRIPTION
This fixes crashes when some log arguments were not serializable for IPC